### PR TITLE
Make oidc ssl cert verification configurable

### DIFF
--- a/src/horreum/configs.py
+++ b/src/horreum/configs.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
-from typing import Optional
 from enum import Enum
+from typing import Optional
 
 import httpx
 from kiota_abstractions.request_option import RequestOption
@@ -27,3 +27,5 @@ class ClientConfiguration:
     options: Optional[dict[str, RequestOption]] = None
     # which authentication method to use
     auth_method: AuthMethod = AuthMethod.BEARER
+    # SSL cert verification against the oidc provider
+    auth_verify: bool = True

--- a/src/horreum/keycloak_access_provider.py
+++ b/src/horreum/keycloak_access_provider.py
@@ -12,7 +12,7 @@ class KeycloakAccessProvider(AccessTokenProvider):
     username: str
     password: str
 
-    def __init__(self, config: KeycloakConfig, username: str, password: str):
+    def __init__(self, config: KeycloakConfig, username: str, password: str, verify: bool = True):
         super()
         self.config = config
         self.username = username
@@ -20,7 +20,8 @@ class KeycloakAccessProvider(AccessTokenProvider):
         self.keycloak_openid = KeycloakOpenID(
             server_url=config.url,
             client_id=config.client_id,
-            realm_name=config.realm
+            realm_name=config.realm,
+            verify=verify
         )
 
     async def get_authorization_token(self, uri: str, additional_authentication_context: Dict[str, Any] = {}) -> str:


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

With this fix we can disable the SSL verification for the Keycloak instance that could be running 

## Changes proposed

- [ ] Add additional client configuration field named `auth_verify` that can be used to disable the SSL verification for the Keycloak instance

> NOTE: this is most likely a temporary fix as we would get rid of the OIDC authentication whenever we would switch to the new API key approach (that is already supported)

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.