### PR TITLE
[0.16.x] Update kiota version to 1.20.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ifneq ($(filter arm%,$(OS_ARCH)),)
 endif
 
 # env variables
-KIOTA_VERSION ?= "v1.18.0"
+KIOTA_VERSION ?= "v1.20.0"
 HORREUM_BRANCH ?= "0.16"
 HORREUM_OPENAPI_PATH ?= "https://raw.githubusercontent.com/Hyperfoil/Horreum/${HORREUM_BRANCH}/docs/site/content/en/openapi/openapi.yaml"
 GENERATED_CLIENT_PATH = "${PROJECT_PATH}/src/horreum/raw_client"


### PR DESCRIPTION
Backport https://github.com/Hyperfoil/horreum-client-python/pull/29

Updating Kiota version to 1.20.0. Verify there are no breaking changes.